### PR TITLE
Remove the base setting from vite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     alias: {
       "@": resolve(__dirname, "src")
     }
-  },
-  base: "/grimwild-ce/"
+  }
 });


### PR DESCRIPTION
Remove the base setting from Vite and rely on a configured domain for GitHub pages to function.